### PR TITLE
Fix enddate for google calendar link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ latlng: "56.337475,-2.794065" # decimal latitude and longitude of workshop venue
 humandate: "Mar 23-24, 2017"  # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "9:30 am - 5:00pm" # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: 2017-03-23 # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
-enddate: 2017-03024   # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
+enddate: 2017-03-25   # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["Alexander Konovalov (University of St Andrews)", "Leighton Pritchard (James Hutton Institute)"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Patrick McCann", "Swithun Crowe", "Calum Lind", "Michael Torpey"]       # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 contact: [" capod@st-andrews.ac.uk"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]


### PR DESCRIPTION
- Fix the typo in enddate.
- Use +1 day for enddate so that the google calendar spans two days.